### PR TITLE
use object pool to optimize memory use in queue.

### DIFF
--- a/lee/stl/deploy.sh
+++ b/lee/stl/deploy.sh
@@ -53,4 +53,6 @@ elif [ "${module}" == "string" ];then
     deploy_string;
 elif [ "${module}" == "queue" ];then
     deploy_queue;
+else
+    help
 fi

--- a/lee/stl/test_queue.cpp
+++ b/lee/stl/test_queue.cpp
@@ -29,12 +29,18 @@ int main() {
     queue<int> q;
     q.push(0);
     q.push(1);
-    q.push(2);
-    q.push(3);
-    q.push(4);
+    // q.push(2);
+    // q.push(3);
+    // q.push(4);
     // test front function
     int res = q.front();
     cout << res << endl;
+
+    // // test memory allocate and free
+    // for (int i = 0; i < 5; i++) {
+    //     q.push(i);
+    //     q.pop();
+    // }
 
     return 0;
 }


### PR DESCRIPTION
use object pool to optimize memory use in queue.
Better idea maybe use smart pointer, but in this version, I use a clear_pool function to free all memory.
valgrind test OK, no memory are leaked.